### PR TITLE
Don't crash when bit for 8 is set in prefix length

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -107,8 +107,10 @@ fn get_rand_ipv6(ipv6: [u8; 16], prefix_len: u8) -> IpAddr {
     let mut ipv6 = ipv6;
     let mut rng = rand::thread_rng();
 
+    // Count full bytes of the network part
     let net_part = (prefix_len + 7) / 8;
-    let las = prefix_len & 8;
+    // Get the number of network bits in the last byte
+    let las = prefix_len % 8;
 
     let mut cur = 15;
     while cur > net_part - 1 {


### PR DESCRIPTION
Using `& 8` on the `prefix_len` will produce `8` if it has thwe bit for 8 set and `0` otherwise. So `las` will sometimes be `8` and sometimes be `0`, and later whjen we shift a byte by `las`, if it is `8`, it fails:

```
thread 'tokio-runtime-worker' panicked at 'attempt to shift right with overflow', src/proxy.rs:121:30
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/panicking.rs:142:14
   2: core::panicking::panic
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/panicking.rs:48:5
   3: http_proxy_ipv6_pool::proxy::get_rand_ipv6
             at ./src/proxy.rs:121:30
   4: http_proxy_ipv6_pool::proxy::Proxy::process_request::{{closure}}
             at ./src/proxy.rs:64:25
...
```

This PR changes the behavior so that `las` can be 0 through 7, but never 8. I'm not certain it ends up having the right value to make the algorithm correct, but it is at least always in range for the shift.